### PR TITLE
Changing repository clone address results in page not updating

### DIFF
--- a/observatory/dashboard/models/Repository.py
+++ b/observatory/dashboard/models/Repository.py
@@ -162,6 +162,8 @@ def clone_git_repo(clone_url, destination_dir, fresh_clone = False):
     clone_cmdline = ["git", "clone", "--mirror", "--bare",
                      clone_url, destination_dir]
   else:
+    update_url_cmdline = ["git", "--git-dir", destination_dir, "remote", "set-url", "origin", clone_url]
+    subprocess.call(update_url_cmdline)
     clone_cmdline = ["git", "--git-dir", destination_dir, "fetch"]
   
   if subprocess.call(clone_cmdline) != 0:


### PR DESCRIPTION
observatory now updates the remote url before fetching, ensures that repository updates will be followed.

Previously, changing the repository clone address for an existing project, when the old address has already been successfully cloned, will result in the observatory failing to track updates correctly. The problem is that once a repository has been cloned successfully, observatory never checks whether the repository url has changed when updating, so it will keep fetching the old repository.
