### PR TITLE
Fixed input element width overflow

### DIFF
--- a/observatory/media/css/forms.css
+++ b/observatory/media/css/forms.css
@@ -17,6 +17,10 @@ input, textarea, select {
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
   border-radius: 5px;
+  
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 textarea {


### PR DESCRIPTION
I added the CSS3 'box-sizing' and major UA variants to include the padding and border in the calculation of 'width: 100%'
