### PR TITLE
Set Debug Mode to False

### DIFF
--- a/observatory/settings.py
+++ b/observatory/settings.py
@@ -1,7 +1,7 @@
 import os
 import django
 
-DEBUG = True
+DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Not sure if intentional, but `DEBUG` is set to `True` in `settings.py` for Observatory.
https://github.com/rcos/Observatory/blob/master/observatory/settings.py#L4

Just some quick testing:
http://rcos.rpi.edu/test  -- prints every URL matching pattern in order for me.  
